### PR TITLE
Do not call kill when there is no jobs.

### DIFF
--- a/server/src/main/java/sf/net/experimaestro/connectors/UnixScriptProcessBuilder.java
+++ b/server/src/main/java/sf/net/experimaestro/connectors/UnixScriptProcessBuilder.java
@@ -141,7 +141,12 @@ public class UnixScriptProcessBuilder extends XPMScriptProcessBuilder {
             }));
 
             // Kills remaining processes
-            writer.println("  jobs -pr | xargs kill");
+            // Compatibility note: --no-run-if-empty is GNU extension so
+            //   we check upstream to use gxargs on OSX.
+            writer.println("  for pid in $(jobs -pr)");
+            writer.println("  do");
+            writer.println("    kill $pid");
+            writer.println("  done");
             writer.format("}%n%n");
 
 


### PR DESCRIPTION
We could have used xargs's --no-run-if-empty option but it is a GNU
extension not available in BSD xargs. Thus, we should have checked
up-front for an available gxargs which would have made the code more
complicated.