### PR TITLE
Closing fd before to call java server is still error-prone.

### DIFF
--- a/server/scripts/experimaestro
+++ b/server/scripts/experimaestro
@@ -112,7 +112,10 @@ def start_jar(args, jarargs):
              open(os.path.join(workdir, "server.err"), "w") as stderr:
             return subprocess.call(command,
                                    stdout=stdout,
-                                   stderr=stderr)
+                                   stderr=stderr,
+                                   # FIXME(Nicolas Despres): Same remarks
+                                   #  than for daemonlib.daemonize().
+                                   close_fds=False)
 
     def wait_server(pid):
         logging.info("Waiting for server to start (PID=%s)...", pid)


### PR DESCRIPTION
This is a temporary fix.

See patch: c32fb0cd372281f581dcddd75fbb7900b3d2f1c3