### PR TITLE
Rework exception handling in experimaestro python frontend script

### DIFF
--- a/server/scripts/experimaestro
+++ b/server/scripts/experimaestro
@@ -51,7 +51,7 @@ class JsonRPCMethod:
 
         error = response.get("error", None)
         if not error is None:
-            raise Exception("Error while calling method %s: [%d] %s" % (self.name, error["code"], error["message"]))
+            raise RuntimeError("Error while calling method %s: [%d] %s" % (self.name, error["code"], error["message"]))
         return response["result"]
 
 class JsonRPCClient:
@@ -102,7 +102,7 @@ def start_jar(args, jarargs):
                 break
 
         if jarpath is None:
-            raise Exception("Could not find experimaestro jar file")
+            raise RuntimeError("Could not find experimaestro jar file")
         command = ["java", "-Xmx1g", "-jar", jarpath] + jarargs
 
     def start_server(logger):
@@ -181,7 +181,7 @@ class Properties:
     def __getitem__(self, name):
         v = self.sub(name, None)
         if v is None:
-            raise Exception("No key '%s' in properties" % name)
+            raise KeyError("No key '%s' in properties" % name)
         return v.map[0]
 
     def keys(self):
@@ -248,7 +248,7 @@ def getProperties(filename):
                 props.set(section + m.group(1), m.group(2))
                 continue
 
-            raise Exception("Could not read line [%s]" % propDef)
+            raise RuntimeError("Could not read line [%s]" % propDef)
 
         return props
 
@@ -265,7 +265,7 @@ class Configuration():
 
         clients = self.config.sub("client", None)
         if clients is None:
-            raise Exception("No client section in configuration file")
+            raise RuntimeError("No client section in configuration file")
 
         if args.server is None:
             if len(clients) > 1:
@@ -276,9 +276,9 @@ class Configuration():
                             args.server = name
                             logging.debug("Default server is %s" % name)
                         else:
-                            raise Exception("More than one client defined as default in configuration file")
+                            raise RuntimeError("More than one client defined as default in configuration file")
                 if args.server is None:
-                    raise Exception("More than one client [%d] in configuration file (%s): use the --server option or make one client the default"
+                    raise RuntimeError("More than one client [%d] in configuration file (%s): use the --server option or make one client the default"
                                     % (len(clients), ",".join(clients.keys())))
             else:
                 for name, client in clients:

--- a/server/scripts/experimaestro
+++ b/server/scripts/experimaestro
@@ -362,31 +362,26 @@ def command_run_js(args):
     if args.debug_port > 0:
         params["debug"] = args.debug_port
 
-    try:
-        code = 0
-        msg = json.dumps({"id": 1, "method": "run-javascript", "params": params})
-        client.send(msg)
-        while client is not None:
-            message = client.recv()
-            o = json.loads(message)
-            if type(o) == dict:
-                if o["id"]:
-                    if o.get("error", 0) != 0:
-                        code = o["error"]["code"]
-                        sys.stderr.write("%s\n" % o["error"]["message"])
-                    break
+    code = 0
+    msg = json.dumps({"id": 1, "method": "run-javascript", "params": params})
+    client.send(msg)
+    while client is not None:
+        message = client.recv()
+        o = json.loads(message)
+        if type(o) == dict:
+            if o["id"]:
+                if o.get("error", 0) != 0:
+                    code = o["error"]["code"]
+                    sys.stderr.write("%s\n" % o["error"]["message"])
+                break
+            else:
+                result = o["result"]
+                if result["stream"] == "out":
+                    sys.stdout.write(result["value"])
                 else:
-                    result = o["result"]
-                    if result["stream"] == "out":
-                        sys.stdout.write(result["value"])
-                    else:
-                        sys.stdout.write(result["value"])
+                    sys.stdout.write(result["value"])
 
-        sys.exit(code)
-    except Exception as e:
-        print(e)
-        sys.exit(1)
-
+    sys.exit(code)
 
 def command_update(args):
     server = Configuration(args).getJsonServer()


### PR DESCRIPTION
Catching Exception is rarely a good idea. Doing so without printing the whole exception backtrace is even worse because users do not have a full diagnostic.

In our particular case, catching exception may silent bug in our code such as KeyError raised because we access the wrong key in a dictionary.

This PR also raise more specific exception than just Exception.